### PR TITLE
Adding ControlFlags class and associated tests

### DIFF
--- a/u2f-ref-code/java/src/com/google/u2f/server/ControlFlags.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/ControlFlags.java
@@ -1,0 +1,92 @@
+package com.google.u2f.server;
+
+/**
+ * If later versions add more fields, this object can store the parsed control byte data. This can
+ * be extended to an arbitrary number of fields, so that many control bytes can be chained together
+ * to allow the server to process many different types of messages.
+ */
+public class ControlFlags {
+  private final boolean userPresence;
+  private final boolean isTransferAccessMessage;
+  
+  private static final byte MASK_USER_PRESENCE = 0x1;
+  private static final byte MASK_TRANSFER_ACCESS_MESSAGE = 0x2;
+
+
+  /**
+   * Hidden constructor, use builder instead
+   *
+   * @param userPresence (optional) true if user verifies presence
+   * @param isTransferAccessMessage (optional) true if these flags are attached to a TransferAccess
+   *        Message
+   */
+  private ControlFlags(boolean userPresence, boolean isTransferAccessMessage) {
+    this.userPresence = userPresence;
+    this.isTransferAccessMessage = isTransferAccessMessage;
+  }
+
+  /**
+   * Build ControlFlags object from a byte Future versions may need to accept a byte array.
+   */
+  public static ControlFlags fromByte(byte controlFlags) {
+    boolean userPresence = (controlFlags & MASK_USER_PRESENCE) != 0;
+    boolean isTransferAccessMessage =
+        (controlFlags & MASK_TRANSFER_ACCESS_MESSAGE) != 0;
+
+    return new ControlFlags.ControlFlagsBuilder()
+        .setUserPresenceBit(userPresence)
+        .setIsTransferAccessMessageBit(isTransferAccessMessage)
+        .build();
+  }
+
+
+  /**
+   * Write ControlFlags out to a byte. In the future, this may return a byte array. As of this
+   * version, only two flags get used, so this returns a single byte.
+   */
+  public static byte toByte(ControlFlags controlFlags) {
+    byte controlByte = 0x0;
+
+    if (controlFlags.getUserPresence()) {
+      controlByte = (byte) (controlByte | MASK_USER_PRESENCE);
+    }
+
+    if (controlFlags.getIsTransferAccessMessage()) {
+      controlByte = (byte) (controlByte | MASK_TRANSFER_ACCESS_MESSAGE);
+    }
+
+    return controlByte;
+  }
+
+  public boolean getUserPresence() {
+    return userPresence;
+  }
+
+  public boolean getIsTransferAccessMessage() {
+    return isTransferAccessMessage;
+  }
+
+  /**
+   * Builder class. When newer versions introduce new flags, add them here. They can be built by
+   * passing an array of bytes if there are more than six flags.
+   */
+  public static class ControlFlagsBuilder {
+    private boolean userPresence;
+    private boolean isTransferAccessMessage;
+
+    public ControlFlagsBuilder setUserPresenceBit(boolean userPresence) {
+      this.userPresence = userPresence;
+      return this;
+    }
+
+    public ControlFlagsBuilder setIsTransferAccessMessageBit(boolean isTransferAccessMessage) {
+      this.isTransferAccessMessage = isTransferAccessMessage;
+      return this;
+    }
+
+    public ControlFlags build() {
+      return new ControlFlags(userPresence, isTransferAccessMessage);
+    }
+
+  }
+}

--- a/u2f-ref-code/java/tests/com/google/u2f/server/ControlFlagsTest.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/server/ControlFlagsTest.java
@@ -1,0 +1,66 @@
+/**
+ * 
+ */
+package com.google.u2f.server;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * @author at
+ *
+ */
+public class ControlFlagsTest {
+  private static final byte USER_PRESENCE_BIT_SET = 0x1;
+  private static final byte TRANSFER_ACCESS_MESSAGE_BIT_SET = 0x2;
+  private static final byte USER_PRESENCE_AND_TRANSFER_ACCESS_BITS_SET = 0x3;
+  private static final byte NO_BITS_SET = 0x0;
+
+  @Test
+  public void testToByteFromByte() {
+    assertEquals(USER_PRESENCE_BIT_SET,
+        ControlFlags.toByte(ControlFlags.fromByte(USER_PRESENCE_BIT_SET)));
+    assertEquals(TRANSFER_ACCESS_MESSAGE_BIT_SET,
+        ControlFlags.toByte(ControlFlags.fromByte(TRANSFER_ACCESS_MESSAGE_BIT_SET)));
+    assertEquals(USER_PRESENCE_AND_TRANSFER_ACCESS_BITS_SET,
+        ControlFlags.toByte(ControlFlags.fromByte(USER_PRESENCE_AND_TRANSFER_ACCESS_BITS_SET)));
+    assertEquals(NO_BITS_SET, ControlFlags.toByte(ControlFlags.fromByte(NO_BITS_SET)));
+  }
+
+  @Test
+  public void testUserPresenceFromByte() {
+    assertTrue(ControlFlags.fromByte(USER_PRESENCE_BIT_SET).getUserPresence());
+    assertTrue(ControlFlags.fromByte(USER_PRESENCE_AND_TRANSFER_ACCESS_BITS_SET).getUserPresence());
+    assertFalse(ControlFlags.fromByte(NO_BITS_SET).getUserPresence());
+    assertFalse(ControlFlags.fromByte(TRANSFER_ACCESS_MESSAGE_BIT_SET).getUserPresence());
+  }
+
+  @Test
+  public void testIsTransferAccessMessageFromByte() {
+    assertTrue(ControlFlags.fromByte(TRANSFER_ACCESS_MESSAGE_BIT_SET).getIsTransferAccessMessage());
+    assertTrue(ControlFlags.fromByte(USER_PRESENCE_AND_TRANSFER_ACCESS_BITS_SET)
+        .getIsTransferAccessMessage());
+    assertFalse(ControlFlags.fromByte(USER_PRESENCE_BIT_SET).getIsTransferAccessMessage());
+    assertFalse(ControlFlags.fromByte(NO_BITS_SET).getIsTransferAccessMessage());
+  }
+
+  @Test
+  public void testBuilder() {
+    assertTrue(new ControlFlags.ControlFlagsBuilder().setUserPresenceBit(true).build().getUserPresence());
+    assertFalse(
+        new ControlFlags.ControlFlagsBuilder().setUserPresenceBit(false).build().getUserPresence());
+    assertFalse(new ControlFlags.ControlFlagsBuilder().build().getUserPresence());
+    assertFalse(new ControlFlags.ControlFlagsBuilder().setIsTransferAccessMessageBit(true).build()
+        .getUserPresence());
+    assertTrue(new ControlFlags.ControlFlagsBuilder().setIsTransferAccessMessageBit(true)
+        .setUserPresenceBit(true).build().getUserPresence());
+    assertFalse(new ControlFlags.ControlFlagsBuilder().setUserPresenceBit(true).build()
+        .getIsTransferAccessMessage());
+    assertTrue(new ControlFlags.ControlFlagsBuilder().setIsTransferAccessMessageBit(true).build()
+        .getIsTransferAccessMessage());
+    assertFalse(new ControlFlags.ControlFlagsBuilder().setIsTransferAccessMessageBit(false).build()
+        .getIsTransferAccessMessage());
+  }
+
+}


### PR DESCRIPTION
 adding ControlFlags class and associated tests. This will deprecate the user presence byte.

@leshi, PTAL
