### PR TITLE
Refactoring processSignResponse to add Server Time.

### DIFF
--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/FinishSignServlet.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/FinishSignServlet.java
@@ -65,7 +65,7 @@ public class FinishSignServlet extends HttpServlet {
 
     SecurityKeyData securityKeyData;
     try {
-      securityKeyData = u2fServer.processSignResponse(signResponse);
+      securityKeyData = u2fServer.processSignResponse(signResponse, System.currentTimeMillis());
     } catch (U2FException e) {
       throw new ServletException("signature didn't verify", e);
     }

--- a/u2f-ref-code/java/src/com/google/u2f/client/impl/U2FClientReferenceImpl.java
+++ b/u2f-ref-code/java/src/com/google/u2f/client/impl/U2FClientReferenceImpl.java
@@ -115,6 +115,7 @@ public class U2FClientReferenceImpl implements U2FClient {
     String clientDataBase64 = Base64.encodeBase64URLSafeString(clientData.getBytes());
 
     server.processSignResponse(
-        new SignResponse(keyHandleBase64, rawAuthenticateResponse64, clientDataBase64, sessionId));
+        new SignResponse(keyHandleBase64, rawAuthenticateResponse64, clientDataBase64, sessionId),
+        System.currentTimeMillis());
   }
 }

--- a/u2f-ref-code/java/src/com/google/u2f/server/U2FServer.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/U2FServer.java
@@ -26,7 +26,8 @@ public interface U2FServer {
   // authentication //
   public U2fSignRequest getSignRequest(String accountName, String appId) throws U2FException;
 
-  public SecurityKeyData processSignResponse(SignResponse signResponse) throws U2FException;
+  public SecurityKeyData processSignResponse(SignResponse signResponse, long currentTimeInMillis)
+      throws U2FException;
 
   // token management //
   public List<SecurityKeyData> getAllSecurityKeys(String accountName);

--- a/u2f-ref-code/java/src/com/google/u2f/server/impl/U2FServerReferenceImpl.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/impl/U2FServerReferenceImpl.java
@@ -207,7 +207,8 @@ public class U2FServerReferenceImpl implements U2FServer {
   }
 
   @Override
-  public SecurityKeyData processSignResponse(SignResponse signResponse) throws U2FException {
+  public SecurityKeyData processSignResponse(SignResponse signResponse, long currentTimeInMillis)
+      throws U2FException {
     Log.info(">> processSignResponse");
 
     String sessionId = signResponse.getSessionId();

--- a/u2f-ref-code/java/src/com/google/u2f/tools/httpserver/servlets/SignFinishServlet.java
+++ b/u2f-ref-code/java/src/com/google/u2f/tools/httpserver/servlets/SignFinishServlet.java
@@ -31,7 +31,7 @@ public class SignFinishServlet extends HtmlServlet {
         req.getParameter("browserData"),
         req.getParameter("sessionId"));
     try {
-      u2fServer.processSignResponse(signResponse);
+      u2fServer.processSignResponse(signResponse, System.currentTimeMillis());
       body.println("Success!!!");
     } catch (U2FException e) {
       body.println("Failure: " + e.toString());

--- a/u2f-ref-code/java/tests/com/google/u2f/client/impl/U2FClientReferenceImplTest.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/client/impl/U2FClientReferenceImplTest.java
@@ -34,6 +34,8 @@ import com.google.u2f.server.messages.SignResponse;
 import com.google.u2f.server.messages.U2fSignRequest;
 
 public class U2FClientReferenceImplTest extends TestVectors {
+  private static final long ENROLLMENT_TIME = 0L;
+  private static final int INITIAL_COUNTER = 0;
 
   @Mock U2FKey mockU2fKey;
   @Mock U2FServer mockU2fServer;
@@ -54,36 +56,36 @@ public class U2FClientReferenceImplTest extends TestVectors {
 
   @Test
   public void testRegister() throws Exception {
-    when(mockU2fServer.getRegistrationRequest(ACCOUNT_NAME, APP_ID_ENROLL)).thenReturn(
-        new RegistrationRequest(U2FConsts.U2F_V2, SERVER_CHALLENGE_ENROLL_BASE64, APP_ID_ENROLL,
-            SESSION_ID));
+    when(mockU2fServer.getRegistrationRequest(ACCOUNT_NAME, APP_ID_ENROLL))
+        .thenReturn(new RegistrationRequest(U2FConsts.U2F_V2, SERVER_CHALLENGE_ENROLL_BASE64,
+            APP_ID_ENROLL, SESSION_ID));
     doNothing().when(mockOriginVerifier).validateOrigin(APP_ID_ENROLL, ORIGIN);
     when(mockU2fKey.register(new RegisterRequest(APP_ID_ENROLL_SHA256, BROWSER_DATA_ENROLL_SHA256)))
         .thenReturn(new RegisterResponse(USER_PUBLIC_KEY_ENROLL_HEX, KEY_HANDLE, VENDOR_CERTIFICATE,
             SIGNATURE_ENROLL));
     when(mockU2fServer.processRegistrationResponse(
-        new RegistrationResponse(REGISTRATION_DATA_BASE64, BROWSER_DATA_ENROLL_BASE64, SESSION_ID), 0L))
-        .thenReturn(new SecurityKeyData(0L, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX, VENDOR_CERTIFICATE, 0));
+        new RegistrationResponse(REGISTRATION_DATA_BASE64, BROWSER_DATA_ENROLL_BASE64, SESSION_ID),
+        ENROLLMENT_TIME))
+            .thenReturn(new SecurityKeyData(ENROLLMENT_TIME, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX,
+                VENDOR_CERTIFICATE, INITIAL_COUNTER));
 
     u2fClient.register(ORIGIN, ACCOUNT_NAME);
   }
 
   @Test
   public void testAuthenticate() throws Exception {
-    when(mockU2fServer.getSignRequest(ACCOUNT_NAME, ORIGIN)).thenReturn(
-        new U2fSignRequest(SERVER_CHALLENGE_SIGN_BASE64,  
-        ImmutableList.of(new RegisteredKey(U2FConsts.U2F_V2, KEY_HANDLE_BASE64, null /* transports */ , APP_ID_SIGN,
-            SESSION_ID))));
+    when(mockU2fServer.getSignRequest(ACCOUNT_NAME, ORIGIN)).thenReturn(new U2fSignRequest(
+        SERVER_CHALLENGE_SIGN_BASE64, ImmutableList.of(new RegisteredKey(U2FConsts.U2F_V2,
+            KEY_HANDLE_BASE64, null /* transports */ , APP_ID_SIGN, SESSION_ID))));
     doNothing().when(mockOriginVerifier).validateOrigin(APP_ID_SIGN, ORIGIN);
-    when(
-        mockU2fKey.authenticate(new AuthenticateRequest(UserPresenceVerifier.USER_PRESENT_FLAG,
-            BROWSER_DATA_SIGN_SHA256, APP_ID_SIGN_SHA256, KEY_HANDLE)))
-        .thenReturn(
-                new AuthenticateResponse(UserPresenceVerifier.USER_PRESENT_FLAG, COUNTER_VALUE,
-                    SIGNATURE_AUTHENTICATE));
+    when(mockU2fKey.authenticate(new AuthenticateRequest(UserPresenceVerifier.USER_PRESENT_FLAG,
+        BROWSER_DATA_SIGN_SHA256, APP_ID_SIGN_SHA256, KEY_HANDLE)))
+            .thenReturn(new AuthenticateResponse(UserPresenceVerifier.USER_PRESENT_FLAG,
+                COUNTER_VALUE, SIGNATURE_AUTHENTICATE));
     when(mockU2fServer.processSignResponse(new SignResponse(KEY_HANDLE_BASE64,
-        SIGN_RESPONSE_DATA_BASE64, BROWSER_DATA_SIGN_BASE64, SESSION_ID), 0L)).thenReturn(
-            new SecurityKeyData(0L, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX, VENDOR_CERTIFICATE, 0));
+        SIGN_RESPONSE_DATA_BASE64, BROWSER_DATA_SIGN_BASE64, SESSION_ID), ENROLLMENT_TIME))
+            .thenReturn(new SecurityKeyData(ENROLLMENT_TIME, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX,
+                VENDOR_CERTIFICATE, INITIAL_COUNTER));
 
     u2fClient.authenticate(ORIGIN, ACCOUNT_NAME);
   }

--- a/u2f-ref-code/java/tests/com/google/u2f/client/impl/U2FClientReferenceImplTest.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/client/impl/U2FClientReferenceImplTest.java
@@ -81,9 +81,9 @@ public class U2FClientReferenceImplTest extends TestVectors {
         .thenReturn(
                 new AuthenticateResponse(UserPresenceVerifier.USER_PRESENT_FLAG, COUNTER_VALUE,
                     SIGNATURE_AUTHENTICATE));
-    when(mockU2fServer.processSignResponse(
-        new SignResponse(KEY_HANDLE_BASE64, SIGN_RESPONSE_DATA_BASE64, BROWSER_DATA_SIGN_BASE64, SESSION_ID)))
-        .thenReturn(new SecurityKeyData(0L, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX, VENDOR_CERTIFICATE, 0));
+    when(mockU2fServer.processSignResponse(new SignResponse(KEY_HANDLE_BASE64,
+        SIGN_RESPONSE_DATA_BASE64, BROWSER_DATA_SIGN_BASE64, SESSION_ID), 0L)).thenReturn(
+            new SecurityKeyData(0L, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX, VENDOR_CERTIFICATE, 0));
 
     u2fClient.authenticate(ORIGIN, ACCOUNT_NAME);
   }

--- a/u2f-ref-code/java/tests/com/google/u2f/server/impl/U2FServerReferenceImplTest.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/server/impl/U2FServerReferenceImplTest.java
@@ -211,7 +211,7 @@ public class U2FServerReferenceImplTest extends TestVectors {
     SignResponse signResponse = new SignResponse(KEY_HANDLE_BASE64, SIGN_RESPONSE_DATA_BASE64,
         BROWSER_DATA_SIGN_BASE64, SESSION_ID);
 
-    u2fServer.processSignResponse(signResponse);
+    u2fServer.processSignResponse(signResponse, 0L);
   }
 
   @Test
@@ -224,7 +224,7 @@ public class U2FServerReferenceImplTest extends TestVectors {
         BROWSER_DATA_SIGN_BASE64, SESSION_ID);
 
     try {
-      u2fServer.processSignResponse(signResponse);
+      u2fServer.processSignResponse(signResponse, 0L);
       fail("expected exception, but didn't get it");
     } catch(U2FException e) {
       assertTrue(e.getMessage().contains("is not a recognized home origin"));
@@ -244,6 +244,6 @@ public class U2FServerReferenceImplTest extends TestVectors {
     SignResponse signResponse = new SignResponse(KEY_HANDLE_2_BASE64, SIGN_DATA_2_BASE64,
         BROWSER_DATA_2_BASE64, SESSION_ID);
 
-    u2fServer.processSignResponse(signResponse);
+    u2fServer.processSignResponse(signResponse, 0L);
   }
 }

--- a/u2f-ref-code/java/tests/com/google/u2f/server/impl/U2FServerReferenceImplTest.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/server/impl/U2FServerReferenceImplTest.java
@@ -44,6 +44,9 @@ import com.google.u2f.server.messages.SignResponse;
 import com.google.u2f.server.messages.U2fSignRequest;
 
 public class U2FServerReferenceImplTest extends TestVectors {
+  private static final long ENROLLMENT_TIME = 0L;
+  private static final int INITIAL_COUNTER = 0;
+
   @Mock ChallengeGenerator mockChallengeGenerator;
   @Mock SessionIdGenerator mockSessionIdGenerator;
   @Mock DataStore mockDataStore;
@@ -64,7 +67,8 @@ public class U2FServerReferenceImplTest extends TestVectors {
     when(mockDataStore.storeSessionData(Matchers.<EnrollSessionData>any())).thenReturn(SESSION_ID);
     when(mockDataStore.getTrustedCertificates()).thenReturn(trustedCertificates);
     when(mockDataStore.getSecurityKeyData(ACCOUNT_NAME)).thenReturn(
-        ImmutableList.of(new SecurityKeyData(0L, KEY_HANDLE, USER_PUBLIC_KEY_SIGN_HEX, VENDOR_CERTIFICATE, 0)));
+        ImmutableList.of(new SecurityKeyData(ENROLLMENT_TIME, KEY_HANDLE, USER_PUBLIC_KEY_SIGN_HEX,
+            VENDOR_CERTIFICATE, INITIAL_COUNTER)));
   }
 
   @Test
@@ -99,10 +103,11 @@ public class U2FServerReferenceImplTest extends TestVectors {
     RegistrationResponse registrationResponse = new RegistrationResponse(REGISTRATION_DATA_BASE64,
         BROWSER_DATA_ENROLL_BASE64, SESSION_ID);
 
-    u2fServer.processRegistrationResponse(registrationResponse, 0L);
+    u2fServer.processRegistrationResponse(registrationResponse, ENROLLMENT_TIME);
 
     verify(mockDataStore).addSecurityKeyData(eq(ACCOUNT_NAME),
-        eq(new SecurityKeyData(0L, null, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX, VENDOR_CERTIFICATE, 0)));
+        eq(new SecurityKeyData(ENROLLMENT_TIME, null, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX,
+            VENDOR_CERTIFICATE, INITIAL_COUNTER)));
   }
 
   @Test
@@ -118,13 +123,13 @@ public class U2FServerReferenceImplTest extends TestVectors {
     RegistrationResponse registrationResponse = new RegistrationResponse(
         REGISTRATION_RESPONSE_DATA_ONE_TRANSPORT_BASE64,
         BROWSER_DATA_ENROLL_BASE64, SESSION_ID);
-    u2fServer.processRegistrationResponse(registrationResponse, 0L);
+    u2fServer.processRegistrationResponse(registrationResponse, ENROLLMENT_TIME);
 
     List<Transports> transports = new LinkedList<Transports>();
     transports.add(Transports.BLUETOOTH_BREDR);
     verify(mockDataStore).addSecurityKeyData(eq(ACCOUNT_NAME),
-        eq(new SecurityKeyData(0L, transports, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX,
-            TRUSTED_CERTIFICATE_ONE_TRANSPORT, 0)));
+        eq(new SecurityKeyData(ENROLLMENT_TIME, transports, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX,
+            TRUSTED_CERTIFICATE_ONE_TRANSPORT, INITIAL_COUNTER)));
   }
 
   @Test
@@ -140,15 +145,15 @@ public class U2FServerReferenceImplTest extends TestVectors {
     RegistrationResponse registrationResponse = new RegistrationResponse(
         REGISTRATION_RESPONSE_DATA_MULTIPLE_TRANSPORTS_BASE64,
         BROWSER_DATA_ENROLL_BASE64, SESSION_ID);
-    u2fServer.processRegistrationResponse(registrationResponse, 0L);
+    u2fServer.processRegistrationResponse(registrationResponse, ENROLLMENT_TIME);
 
     List<Transports> transports = new LinkedList<Transports>();
     transports.add(Transports.BLUETOOTH_BREDR);
     transports.add(Transports.BLUETOOTH_LOW_ENERGY);
     transports.add(Transports.NFC);
     verify(mockDataStore).addSecurityKeyData(eq(ACCOUNT_NAME),
-        eq(new SecurityKeyData(0L, transports, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX,
-            TRUSTED_CERTIFICATE_MULTIPLE_TRANSPORTS, 0)));
+        eq(new SecurityKeyData(ENROLLMENT_TIME, transports, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX,
+            TRUSTED_CERTIFICATE_MULTIPLE_TRANSPORTS, INITIAL_COUNTER)));
   }
 
   @Test
@@ -164,11 +169,12 @@ public class U2FServerReferenceImplTest extends TestVectors {
     RegistrationResponse registrationResponse = new RegistrationResponse(
         REGISTRATION_RESPONSE_DATA_MALFORMED_TRANSPORTS_BASE64,
         BROWSER_DATA_ENROLL_BASE64, SESSION_ID);
-    u2fServer.processRegistrationResponse(registrationResponse, 0L);
+    u2fServer.processRegistrationResponse(registrationResponse, ENROLLMENT_TIME);
 
     verify(mockDataStore).addSecurityKeyData(eq(ACCOUNT_NAME),
-        eq(new SecurityKeyData(0L, null /* transports */, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX,
-            TRUSTED_CERTIFICATE_MALFORMED_TRANSPORTS_EXTENSION, 0)));
+        eq(new SecurityKeyData(ENROLLMENT_TIME, null /* transports */, KEY_HANDLE,
+            USER_PUBLIC_KEY_ENROLL_HEX, TRUSTED_CERTIFICATE_MALFORMED_TRANSPORTS_EXTENSION,
+            INITIAL_COUNTER)));
   }
 
   @Test
@@ -185,10 +191,10 @@ public class U2FServerReferenceImplTest extends TestVectors {
     RegistrationResponse registrationResponse = new RegistrationResponse(REGISTRATION_DATA_2_BASE64,
         BROWSER_DATA_2_BASE64, SESSION_ID);
 
-    u2fServer.processRegistrationResponse(registrationResponse, 0L);
+    u2fServer.processRegistrationResponse(registrationResponse, ENROLLMENT_TIME);
     verify(mockDataStore).addSecurityKeyData(eq(ACCOUNT_NAME),
-        eq(new SecurityKeyData(0L, null /* transports */, KEY_HANDLE_2, USER_PUBLIC_KEY_2,
-            TRUSTED_CERTIFICATE_2, 0)));
+        eq(new SecurityKeyData(ENROLLMENT_TIME, null /* transports */, KEY_HANDLE_2, USER_PUBLIC_KEY_2,
+            TRUSTED_CERTIFICATE_2, INITIAL_COUNTER)));
   }
 
   @Test
@@ -211,7 +217,7 @@ public class U2FServerReferenceImplTest extends TestVectors {
     SignResponse signResponse = new SignResponse(KEY_HANDLE_BASE64, SIGN_RESPONSE_DATA_BASE64,
         BROWSER_DATA_SIGN_BASE64, SESSION_ID);
 
-    u2fServer.processSignResponse(signResponse, 0L);
+    u2fServer.processSignResponse(signResponse, ENROLLMENT_TIME);
   }
 
   @Test
@@ -224,7 +230,7 @@ public class U2FServerReferenceImplTest extends TestVectors {
         BROWSER_DATA_SIGN_BASE64, SESSION_ID);
 
     try {
-      u2fServer.processSignResponse(signResponse, 0L);
+      u2fServer.processSignResponse(signResponse, ENROLLMENT_TIME);
       fail("expected exception, but didn't get it");
     } catch(U2FException e) {
       assertTrue(e.getMessage().contains("is not a recognized home origin"));
@@ -237,13 +243,14 @@ public class U2FServerReferenceImplTest extends TestVectors {
   public void testProcessSignResponse2() throws U2FException {
     when(mockDataStore.getSignSessionData(SESSION_ID)).thenReturn(
         new SignSessionData(ACCOUNT_NAME, APP_ID_2, SERVER_CHALLENGE_SIGN, USER_PUBLIC_KEY_2));
-    when(mockDataStore.getSecurityKeyData(ACCOUNT_NAME)).thenReturn(
-        ImmutableList.of(new SecurityKeyData(0l, KEY_HANDLE_2, USER_PUBLIC_KEY_2, VENDOR_CERTIFICATE, 0)));
-    u2fServer = new U2FServerReferenceImpl(mockChallengeGenerator,
-        mockDataStore, crypto, TRUSTED_DOMAINS);
+    when(mockDataStore.getSecurityKeyData(ACCOUNT_NAME))
+        .thenReturn(ImmutableList.of(new SecurityKeyData(ENROLLMENT_TIME, KEY_HANDLE_2,
+            USER_PUBLIC_KEY_2, VENDOR_CERTIFICATE, INITIAL_COUNTER)));
+    u2fServer =
+        new U2FServerReferenceImpl(mockChallengeGenerator, mockDataStore, crypto, TRUSTED_DOMAINS);
     SignResponse signResponse = new SignResponse(KEY_HANDLE_2_BASE64, SIGN_DATA_2_BASE64,
         BROWSER_DATA_2_BASE64, SESSION_ID);
 
-    u2fServer.processSignResponse(signResponse, 0L);
+    u2fServer.processSignResponse(signResponse, ENROLLMENT_TIME);
   }
 }


### PR DESCRIPTION
Registration of SecurityKeys requires the server time. Adding Server Time to SignResponse for TransferAccess.
