### PR TITLE
Update AuthenticateResponse and refactor UserPesence to ControlFlags.

### DIFF
--- a/u2f-ref-code/java/src/com/google/u2f/codec/RawMessageCodec.java
+++ b/u2f-ref-code/java/src/com/google/u2f/codec/RawMessageCodec.java
@@ -162,13 +162,13 @@ public class RawMessageCodec {
 
   public static byte[] encodeAuthenticateResponse(AuthenticateResponse authenticateResponse)
       throws U2FException {
-    byte userPresence = authenticateResponse.getUserPresence();
+    byte controlFlags = authenticateResponse.getControlFlagByte();
     int counter = authenticateResponse.getCounter();
     byte[] signature = authenticateResponse.getSignature();
 
     byte[] result = new byte[1 + 4 + signature.length];
     ByteBuffer.wrap(result)
-    .put(userPresence)
+    .put(controlFlags)
     .putInt(counter)
     .put(signature);
     return result;
@@ -177,7 +177,7 @@ public class RawMessageCodec {
   public static AuthenticateResponse decodeAuthenticateResponse(byte[] data) throws U2FException {
     try {
       DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(data));
-      byte userPresence = inputStream.readByte();
+      byte controlFlags = inputStream.readByte();
       int counter = inputStream.readInt();
       byte[] signature = new byte[inputStream.available()];
       inputStream.readFully(signature);
@@ -186,7 +186,7 @@ public class RawMessageCodec {
         throw new U2FException("Message ends with unexpected data");
       }
 
-      return new AuthenticateResponse(userPresence, counter, signature);
+      return new AuthenticateResponse(controlFlags, counter, signature);
     } catch (IOException e) {
       throw new U2FException("Error when parsing raw AuthenticateResponse", e);
     }
@@ -205,12 +205,12 @@ public class RawMessageCodec {
     return signedData;
   }
 
-  public static byte[] encodeAuthenticateSignedBytes(byte[] applicationSha256, byte userPresence,
+  public static byte[] encodeAuthenticateSignedBytes(byte[] applicationSha256, byte controlFlags,
       int counter, byte[] challengeSha256) {
     byte[] signedData = new byte[applicationSha256.length + 1 + 4 + challengeSha256.length];
     ByteBuffer.wrap(signedData)
     .put(applicationSha256)
-    .put(userPresence)
+    .put(controlFlags)
     .putInt(counter)
     .put(challengeSha256);
     return signedData;

--- a/u2f-ref-code/java/src/com/google/u2f/key/messages/AuthenticateResponse.java
+++ b/u2f-ref-code/java/src/com/google/u2f/key/messages/AuthenticateResponse.java
@@ -9,27 +9,29 @@ package com.google.u2f.key.messages;
 import java.util.Arrays;
 import java.util.Objects;
 
+import com.google.common.base.Preconditions;
+
 public class AuthenticateResponse extends U2FResponse {
-  private final byte userPresence;
+  private final byte controlFlags;
   private final int counter;
   private final byte[] signature;
 
-  public AuthenticateResponse(byte userPresence, int counter, byte[] signature) {
+  public AuthenticateResponse(byte controlFlags, int counter, byte[] signature) {
     super();
-    this.userPresence = userPresence;
+    this.controlFlags = controlFlags;
     this.counter = counter;
-    this.signature = signature;
+    this.signature = Preconditions.checkNotNull(signature);
   }
 
   /**
-   * Bit 0 is set to 1, which means that user presence was verified. (This
-   * version of the protocol doesn't specify a way to request authentication
-   * responses without requiring user presence.) A different value of Bit 0, as
-   * well as Bits 1 through 7, are reserved for future use. The values of Bit 1
-   * through 7 SHOULD be 0
+   * Returns a byte of flags. Setting the least significant bit indicates that user presence was 
+   * verified. (This version of the protocol doesn't specify a way to request authentication 
+   * responses without requiring user presence.) Setting the second least significant bit indicates
+   * this response contains a TransferAccessMessage. A different value for the LSB as well as the 
+   * remaining bits are reserved for future use.
    */
-  public byte getUserPresence() {
-    return userPresence;
+  public byte getControlFlagByte() {
+    return controlFlags;
   }
 
   /**
@@ -47,7 +49,7 @@ public class AuthenticateResponse extends U2FResponse {
 
   @Override
   public int hashCode() {
-    return Objects.hash(userPresence, counter, signature);
+    return Objects.hash(controlFlags, counter, signature);
   }
 
   @Override
@@ -61,6 +63,6 @@ public class AuthenticateResponse extends U2FResponse {
     AuthenticateResponse other = (AuthenticateResponse) obj;
     return Objects.equals(counter, other.counter)
         && Arrays.equals(signature, other.signature)
-        && Objects.equals(userPresence, other.userPresence);
+        && Objects.equals(controlFlags, other.controlFlags);
   }
 }

--- a/u2f-ref-code/java/src/com/google/u2f/key/messages/AuthenticateResponse.java
+++ b/u2f-ref-code/java/src/com/google/u2f/key/messages/AuthenticateResponse.java
@@ -24,7 +24,7 @@ public class AuthenticateResponse extends U2FResponse {
   }
 
   /**
-   * Returns a byte of flags. Setting the least significant bit indicates that user presence was 
+   * Returns a bitfield of flags. Setting the least significant bit indicates that user presence was 
    * verified. (This version of the protocol doesn't specify a way to request authentication 
    * responses without requiring user presence.) Setting the second least significant bit indicates
    * this response contains a TransferAccessMessage. A different value for the LSB as well as the 

--- a/u2f-ref-code/java/src/com/google/u2f/key/messages/TransferAccessResponse.java
+++ b/u2f-ref-code/java/src/com/google/u2f/key/messages/TransferAccessResponse.java
@@ -39,7 +39,7 @@ public class TransferAccessResponse extends AuthenticateResponse {
    * significant bit should be set to 1 to indicate this is a transferAccessResponse.
    */
   public ControlFlags getControlFlags() {
-    return ControlFlags.fromByte(super.getUserPresence());
+    return ControlFlags.fromByte(super.getControlFlagByte());
   }
 
   /** An array of transferAccessMessages in the order in which they need to be processed */

--- a/u2f-ref-code/java/src/com/google/u2f/server/impl/U2FServerReferenceImpl.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/impl/U2FServerReferenceImpl.java
@@ -251,16 +251,16 @@ public class U2FServerReferenceImpl implements U2FServer {
 
     AuthenticateResponse authenticateResponse =
         RawMessageCodec.decodeAuthenticateResponse(rawSignData);
-    byte userPresence = authenticateResponse.getUserPresence();
+    byte controlFlags = authenticateResponse.getControlFlagByte();
     int counter = authenticateResponse.getCounter();
     byte[] signature = authenticateResponse.getSignature();
 
     Log.info("-- Parsed rawSignData --");
-    Log.info("  userPresence: " + Integer.toHexString(userPresence & 0xFF));
+    Log.info("  controlFlags: " + Integer.toHexString(controlFlags & 0xFF));
     Log.info("  counter: " + counter);
     Log.info("  signature: " + Hex.encodeHexString(signature));
 
-    if ((userPresence & UserPresenceVerifier.USER_PRESENT_FLAG) == 0) {
+    if ((controlFlags & UserPresenceVerifier.USER_PRESENT_FLAG) == 0) {
       throw new U2FException("User presence invalid during authentication");
     }
 
@@ -271,7 +271,7 @@ public class U2FServerReferenceImpl implements U2FServer {
     byte[] appIdSha256 = crypto.computeSha256(appId.getBytes());
     byte[] browserDataSha256 = crypto.computeSha256(browserData.getBytes());
     byte[] signedBytes = RawMessageCodec.encodeAuthenticateSignedBytes(
-        appIdSha256, userPresence, counter, browserDataSha256);
+        appIdSha256, controlFlags, counter, browserDataSha256);
 
     Log.info("Verifying signature of bytes " + Hex.encodeHexString(signedBytes));
     if (!crypto.verifySignature(

--- a/u2f-ref-code/java/tests/com/google/u2f/key/impl/U2FKeyReferenceImplTest.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/key/impl/U2FKeyReferenceImplTest.java
@@ -90,7 +90,7 @@ public class U2FKeyReferenceImplTest extends TestVectors {
 
     AuthenticateResponse authenticateResponse = u2fKey.authenticate(authenticateRequest);
 
-    assertEquals(UserPresenceVerifier.USER_PRESENT_FLAG, authenticateResponse.getUserPresence());
+    assertEquals(UserPresenceVerifier.USER_PRESENT_FLAG, authenticateResponse.getControlFlagByte());
     assertEquals(COUNTER_VALUE, authenticateResponse.getCounter());
     Signature ecdsaSignature = Signature.getInstance("SHA256withECDSA");
     ecdsaSignature.initVerify(USER_PUBLIC_KEY_SIGN);


### PR DESCRIPTION
Checking for Null inputs to AuthenticateResponse and to use ControlFlags instead of userPresence.
Related UserPresence fields and methods in other fields have been changed to ControlFlags as well.
