### PR TITLE
Update RawMessageCodec and tests

### DIFF
--- a/u2f-ref-code/java/src/com/google/u2f/codec/RawMessageCodec.java
+++ b/u2f-ref-code/java/src/com/google/u2f/codec/RawMessageCodec.java
@@ -202,9 +202,6 @@ public class RawMessageCodec {
       DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(data));
       byte controlByte = inputStream.readByte();
 
-      if (!inputStream.markSupported()) {
-        throw new U2FException("Stream doesn't support mark and reset.");
-      }
       inputStream.mark(inputStream.available());
       int numberOfTransferAccessMessages = inputStream.readUnsignedByte();
       inputStream.reset();
@@ -245,10 +242,6 @@ public class RawMessageCodec {
         new TransferAccessMessage[numberOfTransferAccessMessages];
 
     try {
-      if (!inputStream.markSupported()) {
-        throw new U2FException("Stream doesn't support mark and reset.");
-      }
-
       for (int i = 0; i < numberOfTransferAccessMessages; i++) {
         inputStream.mark(inputStream.available());
         inputStream.skipBytes(sequenceNumberSize + publicKeySize + appIdSize);

--- a/u2f-ref-code/java/src/com/google/u2f/codec/RawMessageCodec.java
+++ b/u2f-ref-code/java/src/com/google/u2f/codec/RawMessageCodec.java
@@ -194,30 +194,30 @@ public class RawMessageCodec {
     }
   }
 
-  public static TransferAccessResponse decodeTransferAccessResponse(byte[] data) 
+  public static TransferAccessResponse decodeTransferAccessResponse(byte[] data)
       throws U2FException {
-    final int SEQUENCE_NUMBER_SIZE = 1;
-    final int PUBLIC_KEY_SIZE = 65;
-    final int APP_ID_SIZE = 32;
-    
-	try {
-	  DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(data));
-	  byte controlByte = inputStream.readByte();
-	  
-	  if (!inputStream.markSupported()) {
-	    throw new U2FException("Stream doesn't support mark and reset.");
-	  }
-	  inputStream.mark(inputStream.available());
+    int sequenceNumberSize = 1;
+    int publicKeySize = 65;
+    int appIdSize = 32;
+
+    try {
+      DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(data));
+      byte controlByte = inputStream.readByte();
+
+      if (!inputStream.markSupported()) {
+        throw new U2FException("Stream doesn't support mark and reset.");
+      }
+      inputStream.mark(inputStream.available());
       int numberOfTransferAccessMessages = inputStream.readUnsignedByte();
       inputStream.reset();
 
       TransferAccessMessage[] transferAccessMessages =
-          new TransferAccessMessage[numberOfTransferAccessMessages];    
-      
-      for (int i = 0; i < numberOfTransferAccessMessages; i ++ ) {
+          new TransferAccessMessage[numberOfTransferAccessMessages];
+
+      for (int i = 0; i < numberOfTransferAccessMessages; i++) {
         inputStream.mark(inputStream.available());
-        inputStream.skipBytes(SEQUENCE_NUMBER_SIZE + PUBLIC_KEY_SIZE + APP_ID_SIZE);
-        
+        inputStream.skipBytes(sequenceNumberSize + publicKeySize + appIdSize);
+
         X509Certificate newAttestationCertificate = (X509Certificate) CertificateFactory
             .getInstance("X.509").generateCertificate(inputStream);
         byte[] newAttestationCertificateBytes;
@@ -234,9 +234,12 @@ public class RawMessageCodec {
         int lengthOfSignatureUsingAttestationKey = inputStream.readUnsignedByte();
         inputStream.reset();
 
+        int lengthField_signatureUsingAttestationKey = 1;
+        int lengthField_signatureUsingPrivateKey = 1;
         int lengthOfRawTransferAccessMessage =
-            SEQUENCE_NUMBER_SIZE + PUBLIC_KEY_SIZE + APP_ID_SIZE + 1 + lengthOfAttestationCertificate
-                + 1 + lengthOfSignatureUsingPrivateKey + lengthOfSignatureUsingAttestationKey;
+            sequenceNumberSize + publicKeySize + appIdSize + lengthOfAttestationCertificate
+                + lengthField_signatureUsingPrivateKey + lengthOfSignatureUsingPrivateKey
+                + lengthField_signatureUsingAttestationKey + lengthOfSignatureUsingAttestationKey;
 
         byte[] rawTransferAccessMessage = new byte[lengthOfRawTransferAccessMessage];
         inputStream.readFully(rawTransferAccessMessage);
@@ -244,7 +247,13 @@ public class RawMessageCodec {
             TransferAccessMessage.fromBytes(rawTransferAccessMessage);
         if (transferAccessMessages[numberOfTransferAccessMessages - i - 1]
             .getMessageSequenceNumber() != numberOfTransferAccessMessages - i) {
-          throw new U2FException("Messages not in order, unexpected sequence number");
+
+          String exceptionString = String.format(
+              "Messages not in order, unexptected sequence number. Expected %d, but got %d.",
+              numberOfTransferAccessMessages - i,
+              transferAccessMessages[numberOfTransferAccessMessages - i - 1]
+                  .getMessageSequenceNumber());
+          throw new U2FException(exceptionString);
         }
       }
 
@@ -253,19 +262,15 @@ public class RawMessageCodec {
       inputStream.readFully(keyHandle);
       int counter = inputStream.readInt();
       byte[] signature = new byte[inputStream.available()];
-	  inputStream.readFully(signature);
-	  
-	  if (inputStream.available() != 0) {
-		throw new U2FException("Message ends with unexpected data");
-	  }
-	  
-	  return new TransferAccessResponse(controlByte, transferAccessMessages, 
-			  keyHandle, counter, signature);
-	} catch	(IOException e) {
-	  throw new U2FException("Error when parsing raw Transfer Access Response", e);
-	} catch (CertificateException e) {
+      inputStream.readFully(signature);
+
+      return new TransferAccessResponse(controlByte, transferAccessMessages, keyHandle, counter,
+          signature);
+    } catch (IOException e) {
+      throw new U2FException("Error when parsing raw Transfer Access Response", e);
+    } catch (CertificateException e) {
       throw new U2FException("Error when parsing attestation certificate", e);
-	}
+    }
   }
   
   public static byte[] encodeRegistrationSignedBytes(byte[] applicationSha256,

--- a/u2f-ref-code/java/tests/com/google/u2f/TestVectors.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/TestVectors.java
@@ -300,6 +300,7 @@ public class TestVectors {
           + "3045022038aa3cedbb2c5b59349031071130894fee62a2dbd9553c063ced4b77" 
           + "868c0a23022100bb60d474eb4e0e4bcf65d20142ab3c8ce7438779e2b2878ef8"
           + "8bb0acb607172e"                                          // END TRANSFER_ACCESS_MESSAGE
+          + "40"                                                                // Key Handle Length
           + "746ee0dcb3891b4fffe151a035c2e878f1dc0dea6c51455b5b32bcfa046974d8" // New Key Handle (B)
           + "f820cc9ca846cfd3b4f429d205d71904475fc143da8cfb61eeeeba69b5bf1d7a"
           + "00000000" // Counter Initial Value
@@ -425,6 +426,7 @@ public class TestVectors {
           + "3045022038aa3cedbb2c5b59349031071130894fee62a2dbd9553c063ced4b77"
           + "868c0a23022100bb60d474eb4e0e4bcf65d20142ab3c8ce7438779e2b2878ef8"
           + "8bb0acb607172e"                                // End TRANSFER_ACCESS_MESSAGE chain
+          + "40"                                                               // Key Handle Length
           + "9b31362dc861c620da55569e7e493d9858d2cb8ec5fc33b75bf809610aee5523" // New Key Handle (D)
           + "5a7f496a803099a3c4f7e288cfa74a2b7f0fffcf70bb4396b7abf4841c46303d"
           + "795245b0" // Counter Initial Value
@@ -629,6 +631,14 @@ public class TestVectors {
           + "30450221008739a7dd67973a270a34081261c9d30048163174fca0e80c14ff72" // Signature using
           + "e449128303022010d1b8edf71fc53814b363582c93fb66306baee74a06eb4f9b" // Authentication Key
           + "1f06d7956aebca");
+  protected static final byte[] EXPECTED_TRANSFER_ACCESS_RESPONSE_SIGNED_BYTES_A_TO_B_TO_C_TO_D = 
+      parseHex("02"                                                             // Control Byte
+          + "795245b0"                                                          // Counter
+          + "ccd6ee2e47baef244d49a222db496bad0ef5b6f93aa7cc4d30c4821b3b9dbc57"  // BROWSER_DATA_SIGN_SHA256
+          + "0472dc3ca63129c6354890309a89f10b51a8f7c49fc2a7ed554f8886fb7fe7ea"  // New Key Handle(D)
+          + "2f0e8a51345478d7a726b55aad8177bbc826d55395442fbb986d2b323c48f918c8"
+          + "d11cd6658622ae73c9372690ca0dc7121ff05724237dab1fb6abaa7063420444"  // Sha256 of TRANSFER_ACCESS_MESSAGE_C_TO_D
+          );
   protected static final byte[] TRANSFER_ACCESS_MESSAGE_SIGNATURE_USING_AUTHENTICATION_KEY_A_TO_B =
       parseHex("30450221008739a7dd67973a270a34081261c9d30048163174fca0e80c14ff72"
           + "e449128303022010d1b8edf71fc53814b363582c93fb66306baee74a06eb4f9b"

--- a/u2f-ref-code/java/tests/com/google/u2f/TestVectors.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/TestVectors.java
@@ -813,8 +813,8 @@ public class TestVectors {
       parseHex("02"                                                             // Control Byte
           + "795245b0"                                                          // Counter
           + "ccd6ee2e47baef244d49a222db496bad0ef5b6f93aa7cc4d30c4821b3b9dbc57"  // BROWSER_DATA_SIGN_SHA256
-          + "0472dc3ca63129c6354890309a89f10b51a8f7c49fc2a7ed554f8886fb7fe7ea"  // New Key Handle(D)
-          + "2f0e8a51345478d7a726b55aad8177bbc826d55395442fbb986d2b323c48f918c8"
+          + "9b31362dc861c620da55569e7e493d9858d2cb8ec5fc33b75bf809610aee5523"  // New Key Handle(D)
+          + "5a7f496a803099a3c4f7e288cfa74a2b7f0fffcf70bb4396b7abf4841c46303d"
           + "d11cd6658622ae73c9372690ca0dc7121ff05724237dab1fb6abaa7063420444"  // Sha256 of TRANSFER_ACCESS_MESSAGE_A_TO_B
           );
   protected static final byte[] TRANSFER_ACCESS_MESSAGE_SIGNATURE_USING_AUTHENTICATION_KEY_A_TO_B =

--- a/u2f-ref-code/java/tests/com/google/u2f/TestVectors.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/TestVectors.java
@@ -300,13 +300,13 @@ public class TestVectors {
           + "3045022038aa3cedbb2c5b59349031071130894fee62a2dbd9553c063ced4b77" 
           + "868c0a23022100bb60d474eb4e0e4bcf65d20142ab3c8ce7438779e2b2878ef8"
           + "8bb0acb607172e"                                          // END TRANSFER_ACCESS_MESSAGE
-          + "40"                                                                // Key Handle Length
+          + "40"                                                               // Key Handle Length
           + "746ee0dcb3891b4fffe151a035c2e878f1dc0dea6c51455b5b32bcfa046974d8" // New Key Handle (B)
           + "f820cc9ca846cfd3b4f429d205d71904475fc143da8cfb61eeeeba69b5bf1d7a"
           + "00000000" // Counter Initial Value
-          + "3045022100c8f9b7f0e33f551f4b8f0b8c3de53b9f9965c4184f73d47f335299" // Signature
-          + "4d26f1ab8802204d7f22780750f5a2e7fc99b28eb7c1a45b68a76e6d234294fa"
-          + "35c6da6e752ed9"
+          + "30450220703a9eb8736b60e107dca45182301224058ba8c14f102e4ba603f7b9" // Signature
+          + "69df24e30221008d91264b306dcb3f5a3aeb6eb5f7c5cfb931043d8932cae3a5"
+          + "e4dd62b13d1fc6"
           );
   protected static final String TRANSFER_ACCESS_RESPONSE_A_TO_B_BASE64 = 
       Base64.encodeBase64URLSafeString(TRANSFER_ACCESS_RESPONSE_A_TO_B); 
@@ -361,8 +361,8 @@ public class TestVectors {
   protected static final byte[] TRANSFER_ACCESS_RESPONSE_A_TO_B_TO_C_TO_D_NO_USER_PRESENCE = 
       parseHex("02"                                                             // Control Byte
           + "03"                                            // TRANSFER_ACCESS_MESSAGE chain, C to D
-          + "0416668f839b4ba154f70f452d8da81bc3fa93979a03cca5e6bec36b64473024"
-          + "0317f932e2833bb4f780a0e81bc13ec392cba3f809794528e923f4af589b7761e4"
+          + "0472dc3ca63129c6354890309a89f10b51a8f7c49fc2a7ed554f8886fb7fe7ea"
+          + "2f0e8a51345478d7a726b55aad8177bbc826d55395442fbb986d2b323c48f918c8"
           + "4b0be934baebb5d12d26011b69227fa5e86df94e7d94aa2949a89f2d493992ca"
           + "3082013c3081e4a003020102020a47901280001155957352300a06082a8648ce"
           + "3d0403023017311530130603550403130c476e756262792050696c6f74301e17"
@@ -430,9 +430,9 @@ public class TestVectors {
           + "9b31362dc861c620da55569e7e493d9858d2cb8ec5fc33b75bf809610aee5523" // New Key Handle (D)
           + "5a7f496a803099a3c4f7e288cfa74a2b7f0fffcf70bb4396b7abf4841c46303d"
           + "795245b0" // Counter Initial Value
-          + "3044022053526d330218638ca6e5dfce157eda2fdab4bb19ee0bfdfb165b322b"  // Signature
-          + "561c1f39022016b661268f6e48f3ad1d9bf2a52ba2f3113292a87a6c5c035671"
-          + "34622a2adfed"
+          + "3046022100f4eb7d82ecf05a5a6e78f194722fab165fe4970d1789a0c894ea5a" // Signature
+          + "4217eacbf2022100f3880dffe75bb9366a0bfb7fe75ac803fee0ae8095ec5d97"
+          + "48e48ad153b65b6f"
           );
   protected static final String TRANSFER_ACCESS_RESPONSE_A_TO_B_TO_C_TO_D_NO_USER_PRESENCE_BASE64 = 
       Base64.encodeBase64URLSafeString(TRANSFER_ACCESS_RESPONSE_A_TO_B_TO_C_TO_D_NO_USER_PRESENCE);
@@ -577,6 +577,176 @@ public class TestVectors {
           + "868c0a23022100bb60d474eb4e0e4bcf65d20142ab3c8ce7438779e2b2878ef8" // Attestation Key
           + "8bb0acb607172e"
           );
+  protected static final byte[] TRANSFER_ACCESS_RESPONSE_A_TO_B_EXTRA_BYTES = 
+      parseHex("03" // Control Byte
+          + "01"                                                          // TRANSFER_ACCESS_MESSAGE
+          + "04269889309e47b66749b855dbc03de26b84ea25b62349c1e09d986bea1f5cd0" 
+          + "f2f3be6b0f2bf7f54eae97764b378bc2313309b2ace492e2b410d97f2e8979c46d"
+          + "4b0be934baebb5d12d26011b69227fa5e86df94e7d94aa2949a89f2d493992ca" 
+          + "3082013c3081e4a003020102020a47901280001155957352300a06082a8648ce"
+          + "3d0403023017311530130603550403130c476e756262792050696c6f74301e17"
+          + "0d3132303831343138323933325a170d3133303831343138323933325a303131"
+          + "2f302d0603550403132650696c6f74476e756262792d302e342e312d34373930"
+          + "313238303030313135353935373335323059301306072a8648ce3d020106082a"
+          + "8648ce3d030107034200048d617e65c9508e64bcc5673ac82a6799da3c144668"
+          + "2c258c463fffdf58dfd2fa3e6c378b53d795c4a4dffb4199edd7862f23abaf02"
+          + "03b4b8911ba0569994e101300a06082a8648ce3d0403020347003044022060cd"
+          + "b6061e9c22262d1aac1d96d8c70829b2366531dda268832cb836bcd30dfa0220"
+          + "631b1459f09e6330055722c8d89b7f48883b9089b88d60d1d9795902b30410df" 
+          + "47"                                    
+          + "30450221008739a7dd67973a270a34081261c9d30048163174fca0e80c14ff72"
+          + "e449128303022010d1b8edf71fc53814b363582c93fb66306baee74a06eb4f9b"
+          + "1f06d7956aebca"
+          + "47"                               
+          + "3045022038aa3cedbb2c5b59349031071130894fee62a2dbd9553c063ced4b77" 
+          + "868c0a23022100bb60d474eb4e0e4bcf65d20142ab3c8ce7438779e2b2878ef8"
+          + "8bb0acb607172e"                                          // END TRANSFER_ACCESS_MESSAGE
+          + "40"                                                               // Key Handle Length
+          + "746ee0dcb3891b4fffe151a035c2e878f1dc0dea6c51455b5b32bcfa046974d8" // New Key Handle (B)
+          + "f820cc9ca846cfd3b4f429d205d71904475fc143da8cfb61eeeeba69b5bf1d7a"
+          + "00000000" // Counter Initial Value
+          + "30450220703a9eb8736b60e107dca45182301224058ba8c14f102e4ba603f7b9" // Signature
+          + "69df24e30221008d91264b306dcb3f5a3aeb6eb5f7c5cfb931043d8932cae3a5"
+          + "e4dd62b13d1fc6"
+          + "deffaf"                                                               // Extra Bytes
+          );
+  protected static final byte[] TRANSFER_ACCESS_RESPONSE_A_TO_B_INVALID_SIGNATURE = 
+      parseHex("03" // Control Byte
+          + "01"                                                          // TRANSFER_ACCESS_MESSAGE
+          + "04269889309e47b66749b855dbc03de26b84ea25b62349c1e09d986bea1f5cd0" 
+          + "f2f3be6b0f2bf7f54eae97764b378bc2313309b2ace492e2b410d97f2e8979c46d"
+          + "4b0be934baebb5d12d26011b69227fa5e86df94e7d94aa2949a89f2d493992ca" 
+          + "3082013c3081e4a003020102020a47901280001155957352300a06082a8648ce"
+          + "3d0403023017311530130603550403130c476e756262792050696c6f74301e17"
+          + "0d3132303831343138323933325a170d3133303831343138323933325a303131"
+          + "2f302d0603550403132650696c6f74476e756262792d302e342e312d34373930"
+          + "313238303030313135353935373335323059301306072a8648ce3d020106082a"
+          + "8648ce3d030107034200048d617e65c9508e64bcc5673ac82a6799da3c144668"
+          + "2c258c463fffdf58dfd2fa3e6c378b53d795c4a4dffb4199edd7862f23abaf02"
+          + "03b4b8911ba0569994e101300a06082a8648ce3d0403020347003044022060cd"
+          + "b6061e9c22262d1aac1d96d8c70829b2366531dda268832cb836bcd30dfa0220"
+          + "631b1459f09e6330055722c8d89b7f48883b9089b88d60d1d9795902b30410df" 
+          + "47"                                    
+          + "30450221008739a7dd67973a270a34081261c9d30048163174fca0e80c14ff72"
+          + "e449128303022010d1b8edf71fc53814b363582c93fb66306baee74a06eb4f9b"
+          + "1f06d7956aebca"
+          + "47"                               
+          + "3045022038aa3cedbb2c5b59349031071130894fee62a2dbd9553c063ced4b77" 
+          + "868c0a23022100bb60d474eb4e0e4bcf65d20142ab3c8ce7438779e2b2878ef8"
+          + "8bb0acb607172e"                                          // END TRANSFER_ACCESS_MESSAGE
+          + "40"                                                               // Key Handle Length
+          + "746ee0dcb3891b4fffe151a035c2e878f1dc0dea6c51455b5b32bcfa046974d8" // New Key Handle (B)
+          + "f820cc9ca846cfd3b4f429d205d71904475fc143da8cfb61eeeeba69b5bf1d7a"
+          + "00000000" // Counter Initial Value
+          + "304402203a8ae240aea2ff9e5a2b72623a01cb78d514f82360ac897cf397131e" // Invalid Signature
+          + "06de3450022044313f61bcca79a3353f89a34a53ddfd1fb6a6d288544c019d85"
+          + "ee1e5ccb95ff"
+          );
+  protected static final byte[] TRANSFER_ACCESS_RESPONSE_A_TO_B_TOO_FEW_BYTES = 
+      parseHex("03" // Control Byte
+          + "01"                                                          // TRANSFER_ACCESS_MESSAGE
+          + "04269889309e47b66749b855dbc03de26b84ea25b62349c1e09d986bea1f5cd0" 
+          + "f2f3be6b0f2bf7f54eae97764b378bc2313309b2ace492e2b410d97f2e8979c46d"
+          + "4b0be934baebb5d12d26011b69227fa5e86df94e7d94aa2949a89f2d493992ca" 
+          + "3082013c3081e4a003020102020a47901280001155957352300a06082a8648ce"
+          + "3d0403023017311530130603550403130c476e756262792050696c6f74301e17"
+          + "0d3132303831343138323933325a170d3133303831343138323933325a303131"
+          + "2f302d0603550403132650696c6f74476e756262792d302e342e312d34373930"
+          + "313238303030313135353935373335323059301306072a8648ce3d020106082a"
+          + "8648ce3d030107034200048d617e65c9508e64bcc5673ac82a6799da3c144668"
+          + "2c258c463fffdf58dfd2fa3e6c378b53d795c4a4dffb4199edd7862f23abaf02"
+          + "03b4b8911ba0569994e101300a06082a8648ce3d0403020347003044022060cd"
+          + "b6061e9c22262d1aac1d96d8c70829b2366531dda268832cb836bcd30dfa0220"
+          + "631b1459f09e6330055722c8d89b7f48883b9089b88d60d1d9795902b30410df" 
+          + "47"                                    
+          + "30450221008739a7dd67973a270a34081261c9d30048163174fca0e80c14ff72"
+          + "e449128303022010d1b8edf71fc53814b363582c93fb66306baee74a06eb4f9b"
+          + "1f06d7956aebca"
+          + "47"                               
+          + "3045022038aa3cedbb2c5b59349031071130894fee62a2dbd9553c063ced4b77" 
+          + "868c0a23022100bb60d474eb4e0e4bcf65d20142ab3c8ce7438779e2b2878ef8"
+          + "8bb0acb607172e"                                          // END TRANSFER_ACCESS_MESSAGE
+          + "40"                                                               // Key Handle Length
+          + "746ee0dcb3891b4fffe151a035c2e878f1dc0dea6c51455b5b32bcfa046974d8" // New Key Handle (B)
+          + "f820cc9ca846cfd3b4f429d205d71904475fc143da8cfb61eeeeba69b5bf1d7a"
+          + "000000"                                                           // Truncated Counter
+          );
+  protected static final byte[] TRANSFER_ACCESS_RESPONSE_TRANSFER_ACCESS_MESSAGES_1_AND_2_OUT_OF_ORDER = 
+      parseHex("02"                                                             // Control Byte
+          + "03"                                            // TRANSFER_ACCESS_MESSAGE chain, C to D
+          + "0416668f839b4ba154f70f452d8da81bc3fa93979a03cca5e6bec36b64473024"
+          + "0317f932e2833bb4f780a0e81bc13ec392cba3f809794528e923f4af589b7761e4"
+          + "4b0be934baebb5d12d26011b69227fa5e86df94e7d94aa2949a89f2d493992ca"
+          + "3082013c3081e4a003020102020a47901280001155957352300a06082a8648ce"
+          + "3d0403023017311530130603550403130c476e756262792050696c6f74301e17"
+          + "0d3132303831343138323933325a170d3133303831343138323933325a303131"
+          + "2f302d0603550403132650696c6f74476e756262792d302e342e312d34373930"
+          + "313238303030313135353935373335323059301306072a8648ce3d020106082a"
+          + "8648ce3d030107034200048d617e65c9508e64bcc5673ac82a6799da3c144668"
+          + "2c258c463fffdf58dfd2fa3e6c378b53d795c4a4dffb4199edd7862f23abaf02"
+          + "03b4b8911ba0569994e101300a06082a8648ce3d0403020347003044022060cd"
+          + "b6061e9c22262d1aac1d96d8c70829b2366531dda268832cb836bcd30dfa0220"
+          + "631b1459f09e6330055722c8d89b7f48883b9089b88d60d1d9795902b30410df" 
+          + "47"
+          + "30450221009b5583388e34bd5efb8699bdb6ecaaf8864322ce7f27ec50b526c0"
+          + "453e75cec202205f4f8371fa9a20b884295946c85995115dbbbd00f43f0e64ce"
+          + "41745e039516d0"
+          + "46"
+          + "304402206108ca00030d57086ac3f41be47bae5a093f35d8e05403e1f3fa8160"
+          + "c7acff77022019cacc489a5fffe89cc89523c35c6743d75bd28fc9b54f289404"
+          + "65da527e3e49"
+          + "01"                                            // TRANSFER_ACCESS_MESSAGE chain, A to B
+          + "04269889309e47b66749b855dbc03de26b84ea25b62349c1e09d986bea1f5cd0" 
+          + "f2f3be6b0f2bf7f54eae97764b378bc2313309b2ace492e2b410d97f2e8979c46d"
+          + "4b0be934baebb5d12d26011b69227fa5e86df94e7d94aa2949a89f2d493992ca" 
+          + "3082013c3081e4a003020102020a47901280001155957352300a06082a8648ce"
+          + "3d0403023017311530130603550403130c476e756262792050696c6f74301e17"
+          + "0d3132303831343138323933325a170d3133303831343138323933325a303131"
+          + "2f302d0603550403132650696c6f74476e756262792d302e342e312d34373930"
+          + "313238303030313135353935373335323059301306072a8648ce3d020106082a"
+          + "8648ce3d030107034200048d617e65c9508e64bcc5673ac82a6799da3c144668"
+          + "2c258c463fffdf58dfd2fa3e6c378b53d795c4a4dffb4199edd7862f23abaf02"
+          + "03b4b8911ba0569994e101300a06082a8648ce3d0403020347003044022060cd"
+          + "b6061e9c22262d1aac1d96d8c70829b2366531dda268832cb836bcd30dfa0220"
+          + "631b1459f09e6330055722c8d89b7f48883b9089b88d60d1d9795902b30410df" 
+          + "47"
+          + "30450221008739a7dd67973a270a34081261c9d30048163174fca0e80c14ff72"
+          + "e449128303022010d1b8edf71fc53814b363582c93fb66306baee74a06eb4f9b"
+          + "1f06d7956aebca"
+          + "47"
+          + "3045022038aa3cedbb2c5b59349031071130894fee62a2dbd9553c063ced4b77"
+          + "868c0a23022100bb60d474eb4e0e4bcf65d20142ab3c8ce7438779e2b2878ef8"
+          + "8bb0acb607172e"           
+          + "02"                                            // TRANSFER_ACCESS_MESSAGE chain, B to C
+          + "0416668f839b4ba154f70f452d8da81bc3fa93979a03cca5e6bec36b64473024" 
+          + "0317f932e2833bb4f780a0e81bc13ec392cba3f809794528e923f4af589b7761e4"
+          + "4b0be934baebb5d12d26011b69227fa5e86df94e7d94aa2949a89f2d493992ca" 
+          + "3082013c3081e4a003020102020a47901280001155957352300a06082a8648ce"
+          + "3d0403023017311530130603550403130c476e756262792050696c6f74301e17"
+          + "0d3132303831343138323933325a170d3133303831343138323933325a303131"
+          + "2f302d0603550403132650696c6f74476e756262792d302e342e312d34373930"
+          + "313238303030313135353935373335323059301306072a8648ce3d020106082a"
+          + "8648ce3d030107034200048d617e65c9508e64bcc5673ac82a6799da3c144668"
+          + "2c258c463fffdf58dfd2fa3e6c378b53d795c4a4dffb4199edd7862f23abaf02"
+          + "03b4b8911ba0569994e101300a06082a8648ce3d0403020347003044022060cd"
+          + "b6061e9c22262d1aac1d96d8c70829b2366531dda268832cb836bcd30dfa0220"
+          + "631b1459f09e6330055722c8d89b7f48883b9089b88d60d1d9795902b30410df" 
+          + "48"                       
+          + "304602210092682c7525159aade790a87079913d7551773bf397da0c071726f9"
+          + "82f047c86f022100a26eedbe8a6e6408d87a255f4451bab8982a936adde01c18"
+          + "7bf293fd5fe57b8d"
+          + "47"
+          + "3045022100f2ebe8c3e201c3ba64a92567a25ed2c5f8b864b05b8730ef70c239"
+          + "055df28ad402201736e5ab3bc6713b8afe8826e1e5395718a63a5a48cc1d3555"
+          + "023d4c6650bc00"                                    // End TRANSFER_ACCESS_MESSAGE chain
+          + "40"                                                               // Key Handle Length
+          + "9b31362dc861c620da55569e7e493d9858d2cb8ec5fc33b75bf809610aee5523" // New Key Handle (D)
+          + "5a7f496a803099a3c4f7e288cfa74a2b7f0fffcf70bb4396b7abf4841c46303d"
+          + "795245b0" // Counter Initial Value
+          + "3046022100f4eb7d82ecf05a5a6e78f194722fab165fe4970d1789a0c894ea5a" // Signature
+          + "4217eacbf2022100f3880dffe75bb9366a0bfb7fe75ac803fee0ae8095ec5d97"
+          + "48e48ad153b65b6f"
+          );
 
   protected static final byte[] EXPECTED_REGISTER_SIGNED_BYTES =
       parseHex("00f0e6a6a97042a4f1f1c87f5f7d44315b2d852c2df5c7991cc66241bf7072d1"
@@ -631,13 +801,21 @@ public class TestVectors {
           + "30450221008739a7dd67973a270a34081261c9d30048163174fca0e80c14ff72" // Signature using
           + "e449128303022010d1b8edf71fc53814b363582c93fb66306baee74a06eb4f9b" // Authentication Key
           + "1f06d7956aebca");
+  protected static final byte[] EXPECTED_TRANSFER_ACCESS_RESPONSE_SIGNED_BYTES_A_TO_B = 
+      parseHex("03"                                                             // Control Byte
+          + "00000000"                                                          // Counter
+          + "ccd6ee2e47baef244d49a222db496bad0ef5b6f93aa7cc4d30c4821b3b9dbc57"  // BROWSER_DATA_SIGN_SHA256
+          + "746ee0dcb3891b4fffe151a035c2e878f1dc0dea6c51455b5b32bcfa046974d8"  // New Key Handle(B)
+          + "f820cc9ca846cfd3b4f429d205d71904475fc143da8cfb61eeeeba69b5bf1d7a"
+          + "465ce92d2284820726e33bcdee5e52b6b3bd0b647197c9635413a11be4da7e75"  // Sha256 of TRANSFER_ACCESS_MESSAGE_C_TO_D
+          );
   protected static final byte[] EXPECTED_TRANSFER_ACCESS_RESPONSE_SIGNED_BYTES_A_TO_B_TO_C_TO_D = 
       parseHex("02"                                                             // Control Byte
           + "795245b0"                                                          // Counter
           + "ccd6ee2e47baef244d49a222db496bad0ef5b6f93aa7cc4d30c4821b3b9dbc57"  // BROWSER_DATA_SIGN_SHA256
           + "0472dc3ca63129c6354890309a89f10b51a8f7c49fc2a7ed554f8886fb7fe7ea"  // New Key Handle(D)
           + "2f0e8a51345478d7a726b55aad8177bbc826d55395442fbb986d2b323c48f918c8"
-          + "d11cd6658622ae73c9372690ca0dc7121ff05724237dab1fb6abaa7063420444"  // Sha256 of TRANSFER_ACCESS_MESSAGE_C_TO_D
+          + "d11cd6658622ae73c9372690ca0dc7121ff05724237dab1fb6abaa7063420444"  // Sha256 of TRANSFER_ACCESS_MESSAGE_A_TO_B
           );
   protected static final byte[] TRANSFER_ACCESS_MESSAGE_SIGNATURE_USING_AUTHENTICATION_KEY_A_TO_B =
       parseHex("30450221008739a7dd67973a270a34081261c9d30048163174fca0e80c14ff72"
@@ -656,14 +834,15 @@ public class TestVectors {
           + "c7acff77022019cacc489a5fffe89cc89523c35c6743d75bd28fc9b54f289404"
           + "65da527e3e49");
   protected static final byte[] TRANSFER_ACCESS_RESPONSE_SIGNATURE_A_TO_B = 
-      parseHex("3045022100c8f9b7f0e33f551f4b8f0b8c3de53b9f9965c4184f73d47f335"
-          + "2994d26f1ab8802204d7f22780750f5a2e7fc99b28eb7c1a45b68a76e6d23429"
-          + "4fa35c6da6e752ed9");
-  protected static final byte[] TRANSFER_ACCESS_RESPONSE_SIGNATURE_A_TO_B_TO_C_TO_D = 
-      parseHex("3044022053526d330218638ca6e5dfce157eda2fdab4bb19ee0bfdfb165b322b"
-          + "561c1f39022016b661268f6e48f3ad1d9bf2a52ba2f3113292a87a6c5c035671"
-          + "34622a2adfed");
-
+      parseHex("30450220703a9eb8736b60e107dca45182301224058ba8c14f102e4ba603f7b9"
+          + "69df24e30221008d91264b306dcb3f5a3aeb6eb5f7c5cfb931043d8932cae3a5"
+          + "e4dd62b13d1fc6"
+          );
+  protected static final byte[] TRANSFER_ACCESS_RESPONSE_SIGNATURE_A_TO_B_TO_C_TO_D =
+      parseHex("3046022100f4eb7d82ecf05a5a6e78f194722fab165fe4970d1789a0c894ea5a"
+          + "4217eacbf2022100f3880dffe75bb9366a0bfb7fe75ac803fee0ae8095ec5d97"
+          + "48e48ad153b65b6f"
+          );
 
   // Test vectors provided by Discretix
   protected static final String APP_ID_2 = APP_ID_ENROLL;

--- a/u2f-ref-code/java/tests/com/google/u2f/codec/RawCodecTest.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/codec/RawCodecTest.java
@@ -28,7 +28,6 @@ public class RawCodecTest extends TestVectors {
   private static final int INITIAL_COUNTER = 0;
   private final Crypto crypto = new BouncyCastleCrypto();
 
-
   @Test
   public void testEncodeRegisterRequest() throws Exception {
     RegisterRequest registerRequest = new RegisterRequest(APP_ID_ENROLL_SHA256,
@@ -145,8 +144,9 @@ public class RawCodecTest extends TestVectors {
         TransferAccessMessage.fromBytes(TRANSFER_ACCESS_MESSAGE_B_TO_C),
         TransferAccessMessage.fromBytes(TRANSFER_ACCESS_MESSAGE_C_TO_D)};
     
-    TransferAccessResponse referenceResponse = new TransferAccessResponse(controlByte, transferAccessMessages, KEY_HANDLE_D,
-        counterValue, TRANSFER_ACCESS_RESPONSE_SIGNATURE_A_TO_B_TO_C_TO_D);
+    TransferAccessResponse referenceResponse =
+        new TransferAccessResponse(controlByte, transferAccessMessages, KEY_HANDLE_D, counterValue,
+            TRANSFER_ACCESS_RESPONSE_SIGNATURE_A_TO_B_TO_C_TO_D);
     
     assertEquals(referenceResponse, transferAccessResponse);
   }
@@ -257,7 +257,7 @@ public class RawCodecTest extends TestVectors {
             controlByte,
             counter,
             BROWSER_DATA_SIGN_SHA256,
-            TRANSFER_ACCESS_PUBLIC_KEY_D_HEX,
+            KEY_HANDLE_D,
             computeSha256(TRANSFER_ACCESS_MESSAGE_C_TO_D)
             );
 


### PR DESCRIPTION
Adding ability to decode TransferAccessResponse and adding associated test skeletons