### PR TITLE
Update ControlFlags.toByte()

### DIFF
--- a/u2f-ref-code/java/src/com/google/u2f/server/ControlFlags.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/ControlFlags.java
@@ -44,14 +44,14 @@ public class ControlFlags {
    * Write ControlFlags out to a byte. In the future, this may return a byte array. As of this
    * version, only two flags get used, so this returns a single byte.
    */
-  public static byte toByte(ControlFlags controlFlags) {
+  public byte toByte() {
     byte controlByte = 0x0;
 
-    if (controlFlags.getUserPresence()) {
+    if (userPresence) {
       controlByte = (byte) (controlByte | MASK_USER_PRESENCE);
     }
 
-    if (controlFlags.getIsTransferAccessResponse()) {
+    if (isTransferAccessResponse) {
       controlByte = (byte) (controlByte | MASK_TRANSFER_ACCESS_RESPONSE);
     }
 

--- a/u2f-ref-code/java/tests/com/google/u2f/key/messages/TransferAccessResponseTest.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/key/messages/TransferAccessResponseTest.java
@@ -7,7 +7,6 @@ import org.junit.Test;
 
 import com.google.u2f.TestVectors;
 import com.google.u2f.U2FException;
-import com.google.u2f.server.ControlFlags;
 
 public class TransferAccessResponseTest extends TestVectors {
   private static final byte CONTROL_FLAGS = 0x03;
@@ -115,7 +114,7 @@ public class TransferAccessResponseTest extends TestVectors {
                                    COUNTER, 
                                    TRANSFER_ACCESS_RESPONSE_SIGNATURE_A_TO_B);
     
-    assertEquals(CONTROL_FLAGS, ControlFlags.toByte(transferAccessResponse.getControlFlags()));
+    assertEquals(CONTROL_FLAGS, transferAccessResponse.getControlFlags().toByte());
     assertArrayEquals(TRANSFER_ACCESS_MESSAGES, transferAccessResponse.getTransferAccessMessages());
     assertArrayEquals(KEY_HANDLE_B, transferAccessResponse.getKeyHandle());
     assertEquals(COUNTER, transferAccessResponse.getCounter());
@@ -132,7 +131,7 @@ public class TransferAccessResponseTest extends TestVectors {
                                    COUNTER, 
                                    TRANSFER_ACCESS_RESPONSE_SIGNATURE_A_TO_B_TO_C_TO_D);
     
-    assertEquals(CONTROL_FLAGS, ControlFlags.toByte(transferAccessResponse.getControlFlags()));
+    assertEquals(CONTROL_FLAGS, transferAccessResponse.getControlFlags().toByte());
     assertArrayEquals(TRANSFER_ACCESS_MESSAGES_OTHER,
         transferAccessResponse.getTransferAccessMessages());
     assertArrayEquals(KEY_HANDLE_B, transferAccessResponse.getKeyHandle());

--- a/u2f-ref-code/java/tests/com/google/u2f/server/ControlFlagsTest.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/server/ControlFlagsTest.java
@@ -13,12 +13,12 @@ public class ControlFlagsTest {
   @Test
   public void testToByteFromByte() {
     assertEquals(USER_PRESENCE_BIT_SET,
-        ControlFlags.toByte(ControlFlags.fromByte(USER_PRESENCE_BIT_SET)));
+        ControlFlags.fromByte(USER_PRESENCE_BIT_SET).toByte());
     assertEquals(TRANSFER_ACCESS_MESSAGE_BIT_SET,
-        ControlFlags.toByte(ControlFlags.fromByte(TRANSFER_ACCESS_MESSAGE_BIT_SET)));
+        ControlFlags.fromByte(TRANSFER_ACCESS_MESSAGE_BIT_SET).toByte());
     assertEquals(USER_PRESENCE_AND_TRANSFER_ACCESS_BITS_SET,
-        ControlFlags.toByte(ControlFlags.fromByte(USER_PRESENCE_AND_TRANSFER_ACCESS_BITS_SET)));
-    assertEquals(NO_BITS_SET, ControlFlags.toByte(ControlFlags.fromByte(NO_BITS_SET)));
+        ControlFlags.fromByte(USER_PRESENCE_AND_TRANSFER_ACCESS_BITS_SET).toByte());
+    assertEquals(NO_BITS_SET, ControlFlags.fromByte(NO_BITS_SET).toByte());
   }
 
   @Test


### PR DESCRIPTION
Update ControlFlags.toByte() to be a non-static method.