### PR TITLE
Replace ByteBuffer with ByteArrayOutputStream in TransferAccessMessage

### DIFF
--- a/u2f-ref-code/java/src/com/google/u2f/key/messages/TransferAccessMessage.java
+++ b/u2f-ref-code/java/src/com/google/u2f/key/messages/TransferAccessMessage.java
@@ -116,19 +116,19 @@ public class TransferAccessMessage {
     }
 
     ByteArrayOutputStream rawTransferAccessMessageByteStream = new ByteArrayOutputStream();
-    try{
-    rawTransferAccessMessageByteStream.write(sequenceNumber);
-    rawTransferAccessMessageByteStream.write(newUserPublicKey);
-    rawTransferAccessMessageByteStream.write(applicationSha256);
-    rawTransferAccessMessageByteStream.write(attestationCertificateBytes);
-    rawTransferAccessMessageByteStream.write((byte)signatureUsingAuthenticationKey.length);
-    rawTransferAccessMessageByteStream.write(signatureUsingAuthenticationKey);
-    rawTransferAccessMessageByteStream.write((byte)signatureUsingAttestationKey.length);
-    rawTransferAccessMessageByteStream.write(signatureUsingAttestationKey);
+    try {
+      rawTransferAccessMessageByteStream.write(sequenceNumber);
+      rawTransferAccessMessageByteStream.write(newUserPublicKey);
+      rawTransferAccessMessageByteStream.write(applicationSha256);
+      rawTransferAccessMessageByteStream.write(attestationCertificateBytes);
+      rawTransferAccessMessageByteStream.write((byte) signatureUsingAuthenticationKey.length);
+      rawTransferAccessMessageByteStream.write(signatureUsingAuthenticationKey);
+      rawTransferAccessMessageByteStream.write((byte) signatureUsingAttestationKey.length);
+      rawTransferAccessMessageByteStream.write(signatureUsingAttestationKey);
     } catch (IOException e) {
       throw new U2FException("Error writing TransferAccessMessage to ByteArrayOutputStream", e);
     }
-    
+
     return rawTransferAccessMessageByteStream.toByteArray();
   }
   


### PR DESCRIPTION
@leshi PTAL. All tests pass.

There are other instances that can be changed, I just changed the files I created.